### PR TITLE
:alembic: Shrink image sizes using webp

### DIFF
--- a/src/components/me/me.jsx
+++ b/src/components/me/me.jsx
@@ -133,8 +133,8 @@ const query = graphql`
     }
     avatarImg: file(relativePath: { eq: "images/avatar.jpg" }) {
       childImageSharp {
-        avatar: fluid(maxWidth: 400, quality: 100) {
-          ...GatsbyImageSharpFluid_tracedSVG
+        avatar: fluid(maxWidth: 400, quality: 90) {
+          ...GatsbyImageSharpFluid_withWebp_tracedSVG
         }
       }
     }

--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -104,7 +104,7 @@ export const query = graphql`
             previewImage {
               childImageSharp {
                 preview: fluid(maxWidth: 750, quality: 80) {
-                  ...GatsbyImageSharpFluid_tracedSVG
+                  ...GatsbyImageSharpFluid_withWebp_tracedSVG
                 }
               }
             }


### PR DESCRIPTION
not supported in safari or IE, so it doesn't improve these loading times.

Closes #186 