### PR TITLE
:lipstick: Adjust link formatting for excerpts

### DIFF
--- a/assets/content/projects/git-art/index.md
+++ b/assets/content/projects/git-art/index.md
@@ -10,7 +10,7 @@ previewImage: "./git-art.png"
 
 ![Git Art](./git-art.png)
 
-My roommate [Tim](https://www.linkedin.com/in/timothylee0/) and I decided to start challenging ourselves with little applications we could develop.
+My roommate Tim [(his LinkedIn)](https://www.linkedin.com/in/timothylee0/) and I decided to start challenging ourselves with little applications we could develop.
 
 The first thing we thought of was a way to decorate your GitHub activity board, example below:
 

--- a/assets/content/projects/ipfs-web-hosting/index.md
+++ b/assets/content/projects/ipfs-web-hosting/index.md
@@ -10,8 +10,8 @@ previewImage: "./IPFS_logo.png"
 
 ![IPFS Logo](./IPFS_logo.png)
 
-2020 has been defined by [The Lockdown](https://www.bbc.co.uk/news/uk-52084517).
-From March to July (and perhaps again, if the [second wave](https://www.bbc.co.uk/news/uk-53159918) is to come), basically everything shut down and we were all forced to spend time with family, and do nothing.
+2020 has been defined by The Lockdown [(yay?)](https://www.bbc.co.uk/news/uk-52084517).
+From March to July (and perhaps again, if the [(potential)](https://www.bbc.co.uk/news/uk-53159918) second wave is to come), basically everything shut down and we were all forced to spend time with family, and do nothing.
 
 Well, around this time I was thinking "what are the problems humanity will face in the next 100 years?", and at some point I will write a little post outlining my daft ideas.
 

--- a/assets/content/projects/monzo-users/index.md
+++ b/assets/content/projects/monzo-users/index.md
@@ -10,7 +10,7 @@ previewImage: "./monzo-users.png"
 
 ![Monzo Users](./monzo-users.png)
 
-[Monzo](monzo.com) is a digital "challenger" bank from the UK.
+Monzo [(here)](monzo.com) is a digital "challenger" bank from the UK.
 
 I thought it would be interesting to use GitHub to automatically update and store data regarding the growth of Monzo's current account user numbers.
 

--- a/assets/content/projects/musish/index.md
+++ b/assets/content/projects/musish/index.md
@@ -14,7 +14,7 @@ previewImage: "./musish.png"
 
 On December 1st 2018, a group of friends and I attended the MLH Local Hack Day in San Francisco.
 
-Made by [myself](https://jamesjarvis.io), [Brychan](https://brychan.io), [Raphaël](https://raphaelvigee.com), and [Filip](https://www.linkedin.com/in/filip-grebowski-b24810116/).
+Made by myself [(me)](https://jamesjarvis.io), Brychan [(link)](https://brychan.io), Raphael [(link)](https://raphaelvigee.com), and Filip [(link)](https://www.linkedin.com/in/filip-grebowski-b24810116/).
 
 This particular hackathon was sponsored by GitHub and Microsoft, and had a theme of creating the best open source project for the community. We came first in San Francisco for our project.
 

--- a/assets/content/projects/one-second-every-day/index.md
+++ b/assets/content/projects/one-second-every-day/index.md
@@ -8,7 +8,7 @@ link: "https://www.youtube.com/playlist?list=PLkusHjaZhA7nFyNLqDfw2zXeXfs3KfxgE"
 
 Since the 23rd June 2016, my 18th birthday, I have been recording one second of every day of my life.
 
-This all started out after watching [Cesar Kuriyama's](http://www.cesarkuriyama.com) [fantastic TED talk](https://www.ted.com/talks/cesar_kuriyama_one_second_every_day) on his project of the same name and nature.
+This all started out after watching Cesar Kuriyama's [(link)](http://www.cesarkuriyama.com) fantastic TED talk [(link)](https://www.ted.com/talks/cesar_kuriyama_one_second_every_day) on his project of the same name and nature.
 
 I wouldn't be lying if I said this has been one of my favourite projects I have ever embarked on in my life. As my care for social media has dwindled, this project has remained. I started this project with the goal of making myself accountable to do at least one worthwhile thing every day, and it has flourished into a way to reflect on my growth as a person.
 

--- a/assets/content/projects/portfolio-site/index.md
+++ b/assets/content/projects/portfolio-site/index.md
@@ -8,8 +8,8 @@ source: "https://github.com/jamesjarvis/jamesjarvis.io"
 previewImage: "./jamesjarvisio.png"
 ---
 
-This very site you are reading, is open source, under the A-GPL licence with all the source code hosted on [GitHub](https://github.com/jamesjarvis/jamesjarvis.io).
-You may fork it and fill in your own data if you wish, which is surprisingly easy to do, all thanks to [Gatsby](https://www.gatsbyjs.org/)!
+This very site you are reading, is open source, under the A-GPL licence with all the source code hosted on GitHub [(fork off)](https://github.com/jamesjarvis/jamesjarvis.io).
+You may fork it and fill in your own data if you wish, which is surprisingly easy to do, all thanks to GatsbyJS [(link)](https://www.gatsbyjs.org/)!
 
 I created this with GatsbyJS as I wanted to have my own personal portfolio site which simply consumes data stored externally (though within the same repo), rather than hard coding everything, which I felt was the issue with many other portfolio sites.
 
@@ -17,7 +17,7 @@ Now, I wanted to have a personal site so I could have a place to publicise the w
 
 I am a little bit cheap however, so after spending \$30 on domain fees I didn't want to spend any more money on actually hosting it. Which brings me to some of my favourite pieces of tech: the free kind.
 
-## How to host for no cost whatsoever.
+## How to host for no cost whatsoever
 
 Since we are already using GitHub as a way to host our source code (for free!), we might as well use the latest and greatest [GitHub Pages](https://pages.github.com) to host the page source files for free as well! (I know right!??).
 

--- a/assets/content/projects/predictions/index.md
+++ b/assets/content/projects/predictions/index.md
@@ -1,7 +1,7 @@
 ---
 type: project
 date: "2020-03"
-title: "📈 COVID-19 (Coronavirus) automatic predictions"
+title: "🦠 COVID-19 (Coronavirus) automatic predictions"
 tech: ["Python"]
 source: "https://github.com/jamesjarvis/corona-infection-prediction-uk"
 ---

--- a/assets/content/projects/risotto-play/index.md
+++ b/assets/content/projects/risotto-play/index.md
@@ -10,7 +10,7 @@ previewImage: "./risotto-play.png"
 
 ![Risotto Play](./risotto-play.png)
 
-Sometime back in 2018, a friend of mine started building his own programming language, ["Risotto"](https://github.com/risotto/risotto) (although I wanted the name to be "Ravioli" so the syntax could be ["Ravioli Ravioli, give me the formuoli"](https://www.youtube.com/watch?v=z9r8Swai8_g&feature=youtu.be&t=32), but I digress).
+Sometime back in 2018, a friend of mine started building his own programming language, "Risotto" [(GitHub link)](https://github.com/risotto/risotto) (although I wanted the name to be "Ravioli" so the syntax could be "Ravioli Ravioli, give me the formuoli" [(lol I know I'm immature)](https://www.youtube.com/watch?v=z9r8Swai8_g&feature=youtu.be&t=32), but I digress).
 
 Anywho, I've enjoyed using services such as [The Go Play Space](https://goplay.space/) and [Repl](https://repl.it/) in the past, and wanted to replicate this kind of environment (whilst paying 0 for hosting) for Risotto.
 

--- a/assets/content/projects/speedtest/index.md
+++ b/assets/content/projects/speedtest/index.md
@@ -11,7 +11,7 @@ previewImage: "./speedtest-calendar.png"
 
 A quick monitoring project.
 
-As anyone from the UK will know, our internet speeds [aren't quite up to par with the rest of the developed world](https://www.speedtest.net/global-index).
+As anyone from the UK will know, our internet speeds aren't quite up to par with the rest of the developed world [(Don't believe me? Check it out)](https://www.speedtest.net/global-index).
 From personal experience, I very rarely achieve the advertised internet speeds, even when directly connected to the router.
 Similarly, some ISP's I have used seem to have loads of dropouts, and fairly poor response to criticisms of speed.
 So, I though I would try to monitor the internet a bit closer, I had a spare RPI hanging around not really doing much besides a minecraft server, and thought it would be an interesting experiment.

--- a/assets/content/projects/whatsupkent/index.md
+++ b/assets/content/projects/whatsupkent/index.md
@@ -12,7 +12,7 @@ previewImage: "./subject_type_dropdown.png"
 
 In October 2019, I was looking for a challenge.
 
-[University](https://www.kent.ac.uk/) was going ok, but I didn't feel stimulated enough, and wanted to see what else there was on offer.
+University [(look mum, I'm on the front page!)](https://web.archive.org/web/20200322103909/https://www.kent.ac.uk/) was going ok, but I didn't feel stimulated enough, and wanted to see what else there was on offer.
 Turns out paying £9k per year to learn from 20 year old textbooks isn't exactly riveting, so I was looking to see what other interesting lectures I could discover on campus.
 Also, my friends and I liked to use disused seminar rooms to work in since the library was often overcrowded and I wanted an easy way to discover which seminar rooms were not being used.
 


### PR DESCRIPTION
Basicaly, Gatsby markdown excerpts do not allow for correct link formatting, and leaves it blank. This PR just adjusts the content of the first 250characters of each page to hide this issue.