### PR TITLE
Fix spelling mistakes and configuration inconsistency

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -5,7 +5,6 @@ baseURL = "https://jamesjarvis.io/"
 defaultContentLanguage = "en"
 enableRobotsTXT = true
 summaryLength = 10
-colorScheme = "ocean"
 
 timeout = '3000s'
 

--- a/content/posts/indoor-garden-timelapse/index.md
+++ b/content/posts/indoor-garden-timelapse/index.md
@@ -13,7 +13,7 @@ Another lockdown project!
 
 For some reason I've been getting into gardening over the lockdown, from building an automatic irrigation system for our newly built vegetable patch to taking part (and winning) a sunflower growing competition, it's about the most interesting thing I could think of doing whilst being stuck in my house during a great spell of weather.
 
-This year, for my birthday I recieved an [indoor vegetable garden](https://amzn.to/31Xp40r), and thought it would be fun to set up a timelapse camera to monitor the plants growing!
+This year, for my birthday I received an [indoor vegetable garden](https://amzn.to/31Xp40r), and thought it would be fun to set up a timelapse camera to monitor the plants growing!
 
 Since I'm currently also slightly addicted to Raspberry Pi's (now up to 4 in my collection!), I thought this would be a good use for one of them.
 

--- a/content/posts/mapping-the-internet-part-two/index.md
+++ b/content/posts/mapping-the-internet-part-two/index.md
@@ -45,7 +45,7 @@ If I was building this to be an actual, scaleable service, then I'd have swallow
 
 ### Whack it in a DB table
 
-Another embarassing thing about the infra for this project is that I'm running the raspberry pi with an 8 year old 1TB external hard drive I had lying around.
+Another embarrassing thing about the infra for this project is that I'm running the raspberry pi with an 8 year old 1TB external hard drive I had lying around.
 
 It's not the fastest and is in fact the biggest performance bottleneck (if I could be bothered, I would have bought an SSD but this isn't worth £80 + dealing with this limitation is interesting enough).
 

--- a/content/posts/whatsupkent/index.md
+++ b/content/posts/whatsupkent/index.md
@@ -17,7 +17,7 @@ I also wanted to stretch my legs and learn a bit of Golang, Kubernetes, Typescri
 
 So, I decided to create a service that would gather all student's timetables and present the information in an easy to use dashboard, to offer students the opportunity to explore other courses in their spare time.
 
-Thanks to the university (accidentally?) publishing student timetables as publically accessible ical links, it proves fairly simple to just brute force and scrape all ical timetables from their website.
+Thanks to the university (accidentally?) publishing student timetables as publicly accessible ical links, it proves fairly simple to just brute force and scrape all ical timetables from their website.
 Of course, having to iterate through 50,000 timetables can be quite time consuming, so I chose [Golang](https://golang.org/) to write the server, thanks to it's remarkably easy multithreading syntax.
 
 Since the data being retrieved was fundamentally relational, I chose to store it in a [graph database called DGraph](https://dgraph.io/).


### PR DESCRIPTION
## Summary
- Fix spelling mistake 'recieved' → 'received' in indoor-garden-timelapse post
- Fix spelling mistake 'publically' → 'publicly' in whatsupkent post
- Fix spelling mistake 'embarassing' → 'embarrassing' in mapping-the-internet-part-two post  
- Remove duplicate colorScheme setting from config.toml (already properly defined in params.toml)

## Test plan
- [x] Verified all spelling corrections are accurate
- [x] Confirmed configuration change removes duplication without breaking functionality
- [x] All changes are non-breaking content fixes

🤖 Generated with [Claude Code](https://claude.ai/code)