### PR TITLE
Per-topic RSS feeds, full-content items, and h-entry microformats

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,3 +1,11 @@
+/* Congo puts Tailwind's `h-screen` on <body>. layouts/baseof.html drops it
+   because microformats2 parsers read any `h-*` class as a root element, which
+   would nest every h-entry inside a bogus `h-screen` item. Same height, no
+   class-name collision. */
+body {
+  height: 100vh;
+}
+
 .preview-tooltip {
   position: fixed;
   z-index: 9999;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,7 +1,5 @@
-/* Congo puts Tailwind's `h-screen` on <body>. layouts/baseof.html drops it
-   because microformats2 parsers read any `h-*` class as a root element, which
-   would nest every h-entry inside a bogus `h-screen` item. Same height, no
-   class-name collision. */
+/* Replaces `h-screen`, dropped from <body> in layouts/baseof.html — mf2 parses
+   any `h-*` class as a root. */
 body {
   height: 100vh;
 }

--- a/content/tags/investments/_index.md
+++ b/content/tags/investments/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Investments"
+description: "Posts about investing — portfolios, markets, and where I put my money"
+---
+
+Longer-form writing about investing: what I hold, why I hold it, and what I get wrong.
+
+I'm not a financial adviser and none of this is advice. It's a record of my own decisions and reasoning, published mostly so future me can see how badly present me judged things.
+
+If this is the only topic you want from me, subscribe to this page's feed rather than the site-wide one.

--- a/layouts/_partials/feed-content.html
+++ b/layouts/_partials/feed-content.html
@@ -1,26 +1,17 @@
-{{- /* Prepares .Content for inclusion in an RSS feed.
-
-  Feed readers strip CSS and do not resolve relative URLs, so the rendered
-  page HTML needs cleaning first:
-    - heading anchor spans are CSS-hidden on the site, but show as a stray "#"
-    - <source>/srcset are responsive-image plumbing readers ignore
-    - the LQIP placeholder is a base64 blob worth kilobytes per image
-    - every URL in this site is relative (see _partials/picture.html)
-
-  Takes a page, returns an HTML string. */ -}}
+{{- /* Cleans .Content for RSS: readers strip CSS and don't resolve relative URLs. */ -}}
 {{- $base := strings.TrimSuffix "/" site.BaseURL -}}
 {{- $c := .Content -}}
 
-{{- /* Drop the hover "#" anchor appended to every heading. */ -}}
+{{- /* CSS-hidden on the site, a stray "#" in a reader. */ -}}
 {{- $c = replaceRE `<span class="absolute top-0 w-6[^"]*">\s*<a[^>]*>#</a>\s*</span>` "" $c -}}
 
-{{- /* Reduce <picture> plumbing to the plain <img> readers can render. */ -}}
+{{- /* <picture> plumbing down to a plain <img>; also drops the base64 LQIP. */ -}}
 {{- $c = replaceRE `<source[^>]*>` "" $c -}}
 {{- $c = replaceRE `\s+srcset="[^"]*"` "" $c -}}
 {{- $c = replaceRE `\s+sizes="[^"]*"` "" $c -}}
 {{- $c = replaceRE `\s+style="background-image:url\(data:image/[^"]*"` "" $c -}}
 
-{{- /* Relative -> absolute. The [^/] guard leaves //host URLs alone. */ -}}
+{{- /* [^/] guard leaves //host URLs alone. */ -}}
 {{- $c = replaceRE `(src|href|poster)="/([^/])` (printf `${1}="%s/${2}` $base) $c -}}
 
 {{- return $c -}}

--- a/layouts/_partials/feed-content.html
+++ b/layouts/_partials/feed-content.html
@@ -1,0 +1,26 @@
+{{- /* Prepares .Content for inclusion in an RSS feed.
+
+  Feed readers strip CSS and do not resolve relative URLs, so the rendered
+  page HTML needs cleaning first:
+    - heading anchor spans are CSS-hidden on the site, but show as a stray "#"
+    - <source>/srcset are responsive-image plumbing readers ignore
+    - the LQIP placeholder is a base64 blob worth kilobytes per image
+    - every URL in this site is relative (see _partials/picture.html)
+
+  Takes a page, returns an HTML string. */ -}}
+{{- $base := strings.TrimSuffix "/" site.BaseURL -}}
+{{- $c := .Content -}}
+
+{{- /* Drop the hover "#" anchor appended to every heading. */ -}}
+{{- $c = replaceRE `<span class="absolute top-0 w-6[^"]*">\s*<a[^>]*>#</a>\s*</span>` "" $c -}}
+
+{{- /* Reduce <picture> plumbing to the plain <img> readers can render. */ -}}
+{{- $c = replaceRE `<source[^>]*>` "" $c -}}
+{{- $c = replaceRE `\s+srcset="[^"]*"` "" $c -}}
+{{- $c = replaceRE `\s+sizes="[^"]*"` "" $c -}}
+{{- $c = replaceRE `\s+style="background-image:url\(data:image/[^"]*"` "" $c -}}
+
+{{- /* Relative -> absolute. The [^/] guard leaves //host URLs alone. */ -}}
+{{- $c = replaceRE `(src|href|poster)="/([^/])` (printf `${1}="%s/${2}` $base) $c -}}
+
+{{- return $c -}}

--- a/layouts/_partials/search.html
+++ b/layouts/_partials/search.html
@@ -1,6 +1,5 @@
-{{- /* Congo v2.14.0 search.html. Only change: `h-screen w-screen` dropped from
-  the wrapper. `fixed inset-0` already sizes it to the viewport, and `h-screen`
-  reads as a microformats2 root class, polluting every page's mf2 output. */ -}}
+{{- /* Congo v2.14.0 search.html; `h-screen w-screen` dropped — mf2 root collision,
+  and `fixed inset-0` already sizes it. */ -}}
 <div
   id="search-wrapper"
   class="invisible fixed inset-0 z-50 flex cursor-default flex-col bg-neutral-500/50 p-4 backdrop-blur-sm dark:bg-neutral-900/50 sm:p-6 md:p-[10vh] lg:p-[12vh]"

--- a/layouts/_partials/search.html
+++ b/layouts/_partials/search.html
@@ -1,0 +1,38 @@
+{{- /* Congo v2.14.0 search.html. Only change: `h-screen w-screen` dropped from
+  the wrapper. `fixed inset-0` already sizes it to the viewport, and `h-screen`
+  reads as a microformats2 root class, polluting every page's mf2 output. */ -}}
+<div
+  id="search-wrapper"
+  class="invisible fixed inset-0 z-50 flex cursor-default flex-col bg-neutral-500/50 p-4 backdrop-blur-sm dark:bg-neutral-900/50 sm:p-6 md:p-[10vh] lg:p-[12vh]"
+  data-url="{{ "" | absLangURL }}"
+>
+  <div
+    id="search-modal"
+    class="top-20 mx-auto flex min-h-0 w-full max-w-3xl flex-col rounded-md border border-neutral-200 bg-neutral shadow-lg dark:border-neutral-700 dark:bg-neutral-800"
+  >
+    <header class="relative z-10 flex flex-none items-center justify-between px-2">
+      <form class="flex min-w-0 flex-auto items-center">
+        <div class="flex h-8 w-8 items-center justify-center text-neutral-400">
+          {{ partial "icon.html" "search" }}
+        </div>
+        <input
+          type="search"
+          id="search-query"
+          class="mx-1 flex h-12 flex-auto appearance-none bg-transparent focus:outline-dotted focus:outline-2 focus:outline-transparent"
+          placeholder="{{ i18n "search.input_placeholder" }}"
+          tabindex="0"
+        />
+      </form>
+      <button
+        id="close-search-button"
+        class="flex h-8 w-8 items-center justify-center text-neutral-700 hover:text-primary-600 dark:text-neutral dark:hover:text-primary-400"
+        title="{{ i18n "search.close_button_title" }}"
+      >
+        {{ partial "icon.html" "xmark" }}
+      </button>
+    </header>
+    <section class="flex-auto overflow-auto px-2">
+      <ul id="search-results"></ul>
+    </section>
+  </div>
+</div>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,7 +1,5 @@
-{{- /* Congo v2.14.0 baseof.html. Only change: Tailwind's `h-screen` is dropped
-  from <body> because microformats2 parsers treat any `h-*` class as a root,
-  which would wrap every h-entry in a bogus `h-screen` item. Height is restored
-  by the `body` rule in assets/css/custom.css. */ -}}
+{{- /* Congo v2.14.0 baseof.html; `h-screen` dropped from <body> — mf2 parses any
+  `h-*` class as a root. Height lives in assets/css/custom.css. */ -}}
 {{- partial "functions/warnings.html" .Site -}}
 {{- partial "functions/init.html" . -}}
 <!doctype html>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,0 +1,59 @@
+{{- /* Congo v2.14.0 baseof.html. Only change: Tailwind's `h-screen` is dropped
+  from <body> because microformats2 parsers treat any `h-*` class as a root,
+  which would wrap every h-entry in a bogus `h-screen` item. Height is restored
+  by the `body` rule in assets/css/custom.css. */ -}}
+{{- partial "functions/warnings.html" .Site -}}
+{{- partial "functions/init.html" . -}}
+<!doctype html>
+<html
+  lang="{{- site.Language.Locale | default "" -}}"
+  dir="{{- site.Language.Direction | default "ltr" -}}"
+  class="scroll-smooth"
+  data-default-appearance="{{- .Site.Params.defaultAppearance | default "light" -}}"
+  data-auto-appearance="{{- .Site.Params.autoSwitchAppearance | default "true" -}}"
+>
+  {{- partial "head.html" . -}}
+  <body
+    class="m-auto flex max-w-7xl flex-col bg-neutral px-6 text-lg leading-7 text-neutral-900 dark:bg-neutral-800 dark:text-neutral sm:px-14 md:px-24 lg:px-32"
+  >
+    <div id="the-top" class="absolute flex self-center">
+      <a
+        class="-translate-y-8 rounded-b-lg bg-primary-200 px-3 py-1 text-sm focus:translate-y-0 dark:bg-neutral-600"
+        href="#main-content"
+        ><span class="pe-2 font-bold text-primary-600 dark:text-primary-400">&darr;</span
+        >{{ i18n "nav.skip_to_main" }}</a
+      >
+    </div>
+    {{ $header := print "header/" .Site.Params.header.layout ".html" }}
+    {{ if templates.Exists ( printf "_partials/%s" $header) }}
+      {{ partial $header . }}
+    {{ else }}
+      {{ partial "header/basic.html" . }}
+    {{ end }}
+    <div class="relative flex grow flex-col">
+      <main id="main-content" class="grow">
+        {{ block "main" . }}{{ end }}
+      </main>
+      {{ if .Site.Params.footer.showScrollToTop | default true }}
+        <div
+          class="pointer-events-none absolute bottom-0 end-0 top-[100vh] w-12"
+          id="to-top"
+          hidden="{{ .Site.Params.footer.showScrollToTop | default true -}}"
+        >
+          <a
+            href="#the-top"
+            class="pointer-events-auto sticky top-[calc(100vh-5.5rem)] flex h-12 w-12 items-center justify-center rounded-full bg-neutral/50 text-xl text-neutral-700 backdrop-blur hover:text-primary-600 dark:bg-neutral-800/50 dark:text-neutral dark:hover:text-primary-400"
+            aria-label="{{ i18n "nav.scroll_to_top_title" }}"
+            title="{{ i18n "nav.scroll_to_top_title" }}"
+          >
+            &uarr;
+          </a>
+        </div>
+      {{ end }}
+      {{- partial "footer.html" . -}}
+      {{ if .Site.Params.enableSearch | default false }}
+        {{- partial "search.html" . -}}
+      {{ end }}
+    </div>
+  </body>
+</html>

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,6 +1,4 @@
-{{- /* Based on Hugo's embedded rss.xml (v0.163.3).
-  Changes: home feed is limited to the posts section, items carry <category>
-  elements per tag, and the home channel uses the site title. */ -}}
+{{- /* Hugo's embedded rss.xml + posts-only home feed, <category>, full content. */ -}}
 {{- $authorEmail := "" }}
 {{- with site.Params.author }}
 	{{- if reflect.IsMap . }}

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,0 +1,82 @@
+{{- /* Based on Hugo's embedded rss.xml (v0.163.3).
+  Changes: home feed is limited to the posts section, items carry <category>
+  elements per tag, and the home channel uses the site title. */ -}}
+{{- $authorEmail := "" }}
+{{- with site.Params.author }}
+	{{- if reflect.IsMap . }}
+		{{- with .email }}
+			{{- $authorEmail = . }}
+		{{- end }}
+	{{- end }}
+{{- end }}
+
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+	{{- if reflect.IsMap . }}
+		{{- with .name }}
+			{{- $authorName = . }}
+		{{- end }}
+	{{- else }}
+		{{- $authorName = . }}
+	{{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
+{{- $pages := slice }}
+{{- if .IsHome }}
+	{{- $pages = where $pctx.RegularPages "Section" "posts" }}
+{{- else if .IsSection }}
+	{{- $pages = $pctx.RegularPages }}
+{{- else }}
+	{{- $pages = $pctx.Pages }}
+{{- end }}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+	{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- $title := .Site.Title }}
+{{- $description := printf "Recent content on %s" .Site.Title }}
+{{- if not .IsHome }}
+	{{- with .Title }}
+		{{- $title = printf "%s on %s" . $.Site.Title }}
+		{{- $description = printf "Recent content in %s on %s" . $.Site.Title }}
+	{{- end }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+	<channel>
+		<title>{{ $title }}</title>
+		<link>{{ .Permalink }}</link>
+		<description>{{ $description }}</description>
+		<generator>Hugo</generator>
+		<language>{{ site.Language.Locale }}</language>
+		{{ with $authorEmail }}
+			<managingEditor>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>
+		{{ end }}
+		{{ with $authorEmail }}
+			<webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>
+		{{ end }}
+		{{ with .Site.Copyright }}
+			<copyright>{{ . }}</copyright>
+		{{ end }}
+		{{ if and (not .Date.IsZero) $pages }}
+			<lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+		{{ end }}
+		{{- with .OutputFormats.Get "RSS" }}
+			{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+		{{- end }}
+		{{- range $pages }}
+			<item>
+				<title>{{ .Title | emojify }}</title>
+				<link>{{ .Permalink }}</link>
+				<pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+				{{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+				<guid>{{ .Permalink }}</guid>
+				{{- range .GetTerms "tags" }}<category>{{ .LinkTitle }}</category>{{ end }}
+				<description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+				<content:encoded>{{ partial "feed-content.html" . | transform.XMLEscape | safeHTML }}</content:encoded>
+			</item>
+		{{- end }}
+	</channel>
+</rss>

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -1,0 +1,82 @@
+{{- /* Congo v2.14.0 single.html, plus microformats2 h-entry markup so IndieWeb
+  readers can follow pages that have no RSS output of their own (e.g. /now/). */ -}}
+{{ define "main" }}
+  {{- $images := .Resources.ByType "image" }}
+  {{- $cover := $images.GetMatch (.Params.cover | default "*cover*") }}
+  {{- $feature := $images.GetMatch (.Params.feature | default "*feature*") | default $cover }}
+  {{- $published := .Date.Format "2006-01-02T15:04:05Z07:00" }}
+  {{- $updated := .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}
+  <article class="h-entry">
+    <header class="max-w-prose">
+      {{ if .Params.showBreadcrumbs | default (.Site.Params.article.showBreadcrumbs | default false) }}
+        {{ partial "breadcrumbs.html" . }}
+      {{ end }}
+      <h1 class="p-name mb-8 mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
+        {{ .Title | emojify }}
+      </h1>
+      {{- /* Machine-readable h-entry properties. Not rendered for humans. */}}
+      <a class="u-url" href="{{ .Permalink }}" hidden></a>
+      {{ if not .Date.IsZero }}<time class="dt-published" datetime="{{ $published }}" hidden></time>{{ end }}
+      {{ if ne $updated $published }}<time class="dt-updated" datetime="{{ $updated }}" hidden></time>{{ end }}
+      {{ with .Site.Params.author.name }}
+        <a class="p-author h-card" href="{{ $.Site.BaseURL }}" hidden>{{ . }}</a>
+      {{ end }}
+      {{ with .Params.summary }}<p class="p-summary" hidden>{{ . }}</p>{{ end }}
+      {{ range .GetTerms "tags" }}
+        <a class="p-category" href="{{ .Permalink }}" hidden>{{ .LinkTitle }}</a>
+      {{ end }}
+      {{ if or
+        (.Params.showDate | default (.Site.Params.article.showDate | default true))
+        (and (.Params.showDateUpdated | default (.Site.Params.article.showDateUpdated | default false)) (ne (partial "functions/date.html" .Date) (partial "functions/date.html" .Lastmod)))
+        (and (.Params.showWordCount | default (.Site.Params.article.showWordCount | default false)) (ne .WordCount 0))
+        (and (.Params.showReadingTime | default (.Site.Params.article.showReadingTime | default true)) (ne .ReadingTime 0))
+        (.Params.showEdit | default (.Site.Params.article.showEdit | default false))
+        (.Params.showTaxonomies | default (.Site.Params.article.showTaxonomies | default false))
+      }}
+        <div class="mb-10 text-base text-neutral-500 dark:text-neutral-400 print:hidden">
+          {{ partial "article-meta.html" (dict "context" . "scope" "single") }}
+        </div>
+      {{ end }}
+      {{ with $feature }}
+        <div class="prose">
+          {{ $altText := $.Params.featureAlt | default $.Params.coverAlt | default "" }}
+          {{ $class := "mb-6 rounded-md" }}
+          {{ $webp := $.Page.Site.Params.enableImageWebp | default true }}
+          {{ partial "picture.html" (dict "img" . "alt" $altText "class" $class "lazy" false "webp" $webp) }}
+          {{ with $.Params.coverCaption }}
+            <figcaption class="-mt-3 mb-6 text-center">{{ . | markdownify }}</figcaption>
+          {{ end }}
+        </div>
+      {{ end }}
+    </header>
+    <section class="prose mt-0 flex max-w-full flex-col dark:prose-invert lg:flex-row">
+      {{ if and (.Params.showTableOfContents | default (.Site.Params.article.showTableOfContents | default false)) (in .TableOfContents "<ul") }}
+        <div class="order-first px-0 lg:order-last lg:max-w-xs lg:ps-8">
+          <div class="toc pe-5 lg:sticky lg:top-10 print:hidden">
+            {{ partial "toc.html" . }}
+          </div>
+        </div>
+      {{ end }}
+      <div class="e-content min-h-0 min-w-0 max-w-prose grow">
+        {{ .Content | emojify }}
+      </div>
+    </section>
+    <footer class="max-w-prose pt-8 print:hidden">
+      {{ partial "author.html" . }}
+      {{ partial "sharing-links.html" . }}
+      {{ partial "article-pagination.html" . }}
+      {{ if .Params.showComments | default (.Site.Params.article.showComments | default false) }}
+        {{ if templates.Exists "_partials/comments.html" }}
+          <div class="pt-3">
+            <hr class="border-dotted border-neutral-300 dark:border-neutral-600" />
+            <div class="pt-3">
+              {{ partial "comments.html" . }}
+            </div>
+          </div>
+        {{ else }}
+          {{ warnf "[CONGO] Comments are enabled for %s but no comments partial exists." .File.Path }}
+        {{ end }}
+      {{ end }}
+    </footer>
+  </article>
+{{ end }}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -1,5 +1,4 @@
-{{- /* Congo v2.14.0 single.html, plus microformats2 h-entry markup so IndieWeb
-  readers can follow pages that have no RSS output of their own (e.g. /now/). */ -}}
+{{- /* Congo v2.14.0 single.html + mf2 h-entry, so IndieWeb readers can follow /now/. */ -}}
 {{ define "main" }}
   {{- $images := .Resources.ByType "image" }}
   {{- $cover := $images.GetMatch (.Params.cover | default "*cover*") }}
@@ -14,7 +13,7 @@
       <h1 class="p-name mb-8 mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">
         {{ .Title | emojify }}
       </h1>
-      {{- /* Machine-readable h-entry properties. Not rendered for humans. */}}
+      {{- /* h-entry properties, hidden from humans. */}}
       <a class="u-url" href="{{ .Permalink }}" hidden></a>
       {{ if not .Date.IsZero }}<time class="dt-published" datetime="{{ $published }}" hidden></time>{{ end }}
       {{ if ne $updated $published }}<time class="dt-updated" datetime="{{ $updated }}" hidden></time>{{ end }}

--- a/layouts/taxonomy.html
+++ b/layouts/taxonomy.html
@@ -1,0 +1,45 @@
+{{- /* Congo v2.14.0 taxonomy.html, plus a per-term RSS link. */ -}}
+{{ define "main" }}
+  <header>
+    {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
+      {{ partial "breadcrumbs.html" . }}
+    {{ end }}
+    <h1 class="mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
+  </header>
+  {{ if .Content }}
+    <section class="prose mt-0 flex max-w-full flex-col dark:prose-invert lg:flex-row">
+      <div class="min-h-0 min-w-0 max-w-prose grow">
+        {{ .Content | emojify }}
+      </div>
+    </section>
+  {{ end }}
+  <section class="-mx-2 flex flex-wrap overflow-hidden">
+    {{ range .Data.Terms }}
+      <article class="my-3 w-full overflow-hidden px-2 sm:w-1/2 md:w-1/3 lg:w-1/4 xl:w-1/5">
+        <h2 class="flex items-center">
+          <a
+            class="text-xl font-medium decoration-primary-500 hover:underline hover:underline-offset-2"
+            href="{{ .Page.Permalink }}"
+            >{{ .Page.Title }}</a
+          >
+          {{ if $.Site.Params.taxonomy.showTermCount | default true }}
+            <span class="px-2 text-base text-primary-500">&middot;</span>
+            <span class="text-base text-neutral-400">
+              {{ .Count }}
+            </span>
+          {{ end }}
+          {{ with .Page.OutputFormats.Get "rss" }}
+            <a
+              class="ps-1 text-neutral-400 hover:text-primary-500 print:hidden"
+              href="{{ .RelPermalink }}"
+              title="Subscribe to this topic"
+              aria-label="Subscribe to this topic via RSS"
+            >
+              {{ partial "icon.html" "rss" }}
+            </a>
+          {{ end }}
+        </h2>
+      </article>
+    {{ end }}
+  </section>
+{{ end }}

--- a/layouts/taxonomy.html
+++ b/layouts/taxonomy.html
@@ -1,4 +1,4 @@
-{{- /* Congo v2.14.0 taxonomy.html, plus a per-term RSS link. */ -}}
+{{- /* Congo v2.14.0 taxonomy.html + per-term RSS link. */ -}}
 {{ define "main" }}
   <header>
     {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}

--- a/layouts/term.html
+++ b/layouts/term.html
@@ -1,4 +1,4 @@
-{{- /* Congo v2.14.0 term.html, plus an RSS subscribe link in the header. */ -}}
+{{- /* Congo v2.14.0 term.html + RSS subscribe link. */ -}}
 {{ define "main" }}
   {{ $toc := and (.Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false)) (in .TableOfContents "<ul") }}
   <header>

--- a/layouts/term.html
+++ b/layouts/term.html
@@ -1,0 +1,65 @@
+{{- /* Congo v2.14.0 term.html, plus an RSS subscribe link in the header. */ -}}
+{{ define "main" }}
+  {{ $toc := and (.Params.showTableOfContents | default (.Site.Params.list.showTableOfContents | default false)) (in .TableOfContents "<ul") }}
+  <header>
+    {{ if .Params.showBreadcrumbs | default (.Site.Params.list.showBreadcrumbs | default false) }}
+      {{ partial "breadcrumbs.html" . }}
+    {{ end }}
+    <h1 class="mt-0 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
+    {{ with .OutputFormats.Get "rss" }}
+      <a
+        class="mt-2 inline-flex items-center text-sm text-neutral-500 decoration-primary-500 hover:underline hover:underline-offset-2 dark:text-neutral-400 print:hidden"
+        href="{{ .RelPermalink }}"
+        title="Subscribe to this topic"
+        aria-label="Subscribe to this topic via RSS"
+      >
+        {{ partial "icon.html" "rss" }}
+        <span class="ps-1">Subscribe to this topic</span>
+      </a>
+    {{ end }}
+  </header>
+  <section
+    class="{{ if $toc -}}
+      mt-12
+    {{- else -}}
+      mt-0
+    {{- end }} prose flex max-w-full flex-col dark:prose-invert lg:flex-row"
+  >
+    {{ if $toc }}
+      <div class="order-first px-0 lg:order-last lg:max-w-xs lg:ps-8">
+        <div class="toc ps-5 lg:sticky lg:top-10">
+          {{ partial "toc.html" . }}
+        </div>
+      </div>
+    {{ end }}
+    <div class="min-h-0 min-w-0 max-w-prose grow">
+      {{ .Content | emojify }}
+    </div>
+  </section>
+  {{ if .Data.Pages }}
+    <section>
+      {{ if $.Params.groupByYear | default ($.Site.Params.list.groupByYear | default true) }}
+        {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+          <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
+            {{ .Key }}
+          </h2>
+          <hr class="w-36 border-dotted border-neutral-400" />
+          {{ range .Pages }}
+            {{ partial "article-link.html" . }}
+          {{ end }}
+        {{ end }}
+      {{ else }}
+        {{ range (.Paginate .Pages).Pages }}
+          {{ partial "article-link.html" . }}
+        {{ end }}
+      {{ end }}
+    </section>
+    {{ partial "pagination.html" . }}
+  {{ else }}
+    <section class="prose mt-10 dark:prose-invert">
+      <p class="border-t py-8">
+        <em>{{ i18n "list.no_articles" | emojify }}</em>
+      </p>
+    </section>
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
Lets people subscribe to one topic instead of the whole firehose, and makes `/now/` followable.

## Per-topic feeds

Hugo was **already** emitting a feed per tag — `term = ["HTML", "RSS", "md"]` has been in the config all along. `/tags/personal-finance/index.xml` existed; nothing linked to it. So this is mostly a discoverability fix:

- `layouts/term.html` — "Subscribe to this topic" link on each tag page
- `layouts/taxonomy.html` — RSS icon per term on `/tags/`

Adds an `Investments` landing page. **No posts are tagged into it yet**, so it won't appear on `/tags/` until some are — Hugo only lists terms with pages.

## Feed quality (`layouts/rss.xml`)

Overrides Hugo's embedded template:

| Change | Why |
|---|---|
| Home feed = posts section only | It drew from `.Site.RegularPages`, so `/now/` appeared as an item |
| `<category>` per tag | Readers can filter |
| Titles emojified | `:map:`, `:umbrella:` were leaking raw into feeds |
| `<content:encoded>` with full body | Renders properly in readers; `<description>` still carries the summary |

Full content needed cleaning first — see `layouts/_partials/feed-content.html`. Every URL on this site is relative (`_partials/picture.html` uses `.RelPermalink` throughout, 411 relative srcs), so raw `.Content` would have shipped broken images to every reader. Also strips heading anchors (CSS-hidden on-site, a stray `#` in a reader), `<source>`/`srcset`, and 189 base64 LQIP blobs.

`transform.AbsURLify` does not exist in any Hugo version — only as an internal rewriter behind `canonifyURLs`, which would apply site-wide. Hence the regex, scoped to the feed.

URLs are derived from `site.BaseURL`, so `hugo server` produces localhost URLs and local testing works normally.

**Size:** home feed 21K → 613K raw / 154K gzipped, and it grows forever (`services.rss.limit = -1`). Per-tag feeds are 10–64K gzipped. Happy to cap the home feed if that's too much.

## Microformats

`/now/` is edited in place, so an RSS item for it would be deduped on guid and never resurface in a reader. h-entry annotation on the existing HTML is the IndieWeb answer — social readers poll the page and use `dt-updated`.

Applied in `single.html`, so posts get it too. Rendering is unchanged for humans.

One unplanned fix: Tailwind's `h-screen` is shaped like an mf2 root class, so Congo's `<body>` was parsing as an `h-screen` item wrapping every h-entry. Dropped from `baseof.html` (height moved to `custom.css`, identical computed value) and from the search overlay, where `fixed inset-0` already sizes the box.

## Verified

- `hugo --minify --gc` clean, no warnings
- `xmllint --noout` — feeds well-formed
- `feedparser` — `bozo: False`, content type `text/html`, 0 relative srcs
- `mf2py` — `/now/` parses as a single top-level `h-entry` with name, url, published, author (h-card), content
- Rendered feed content in a browser with no site CSS; images load, no stray `#`
- Home feed diff: exactly one item removed (`Now`), 44 posts unchanged

## Note on maintenance

Congo is a Hugo Module, and this takes the override count from 10 partials to 16 files. `baseof.html`, `single.html`, `term.html`, `taxonomy.html` and `search.html` are near-verbatim copies of Congo v2.14.0 with small marked changes — they'll need re-syncing on theme upgrades. Each carries a comment saying what was changed and why.

Also deletes `_vendor/`, which held 0 files (empty dirs from an aborted `hugo mod vendor`) and was untracked — Hugo prefers `_vendor` when present, which makes for confusing local builds.

## Follow-ups, not in this PR

1. Tag posts with `investments`
2. Bump `date` in `content/now/index.md` when editing it — `dt-updated` reads `.Lastmod`, which falls back to `date`
3. `content/tags/_index.md` is 0 bytes, so `/tags/` renders a blank `<h1>` (pre-existing)

https://claude.ai/code/session_01SbCawjKd1ks5ZnTSyxXqLJ